### PR TITLE
Add CWP incident acknowledgement method and bulk archiver script

### DIFF
--- a/prismacloud/api/compute/_audits.py
+++ b/prismacloud/api/compute/_audits.py
@@ -13,6 +13,11 @@ class AuditsPrismaCloudAPIComputeMixin:
         audits = self.execute_compute('GET', 'api/v1/audits/%s?' % audit_type, query_params=query_params, paginated=True)
         return audits
 
+    def audits_ack_incident(self, incident_id, ack_status = True):
+        body_params = {"acknowledged": ack_status}
+        resp = self.execute_compute('PATCH', 'api/v1/audits/incidents/acknowledge/%s' % incident_id, body_params=body_params)
+        return resp
+
     # Other related and undocumented endpoints.
 
     # Compute > Monitor > Events

--- a/prismacloud/api/compute/_tags.py
+++ b/prismacloud/api/compute/_tags.py
@@ -14,17 +14,17 @@ class TagsPrismaCloudAPIComputeMixin:
         return result
 
     def tag_delete(self, tag_id):
-        result = self.execute_compute('DELETE', 'api/v1/tags/%s', % tag_id)
+        result = self.execute_compute('DELETE', 'api/v1/tags/%s' % tag_id)
         return result
 
     def tag_update(self, tag_id, body_params):
-        result = self.execute_compute('PUT', 'api/v1/tags/%s', % tag_id, body_params=body_params)
+        result = self.execute_compute('PUT', 'api/v1/tags/%s' % tag_id, body_params=body_params)
         return result
 
     def tag_delete_vulnerability(self, tag_id, body_params):
-        result = self.execute_compute('PUT', 'api/v1/tags/%s/vuln', % tag_id, body_params=body_params)
+        result = self.execute_compute('PUT', 'api/v1/tags/%s/vuln' % tag_id, body_params=body_params)
         return result
 
     def tag_set_vulnerability(self, tag_id, body_params):
-        result = self.execute_compute('POST', 'api/v1/tags/%s/vuln', % tag_id, body_params=body_params)
+        result = self.execute_compute('POST', 'api/v1/tags/%s/vuln' % tag_id, body_params=body_params)
         return result

--- a/prismacloud/api/version.py
+++ b/prismacloud/api/version.py
@@ -1,3 +1,3 @@
 """ version file """
 
-version = '4.1.0'
+version = '4.2.0'

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -203,6 +203,49 @@ You can specifically disable forwarding of Audits with `--no_audit_events`.
 
 Note that `--host_forensic_activities` results in high-volume/time-intensive API calls.
 
+#### pcs_incident_archiver
+
+Use this script to archive runtime incidents in bulk based on the contents of a CSV file.
+
+Workflow:
+
+1. Navigate to Compute > Monitor > Runtime > Incident Explorer > Active.
+1. Click the "CSV" button to export active incidents.
+1. Remove (e.g. in Excel, Google Sheets, etc) rows that should NOT be archived.
+1. Save the CSV.
+1. Invoke this script on the saved CSV to archive each incident it contains.
+
+Assumptions:
+
+- The input CSV file MUST have a header row.
+- The header row for incident IDs MUST be named `ID`.
+
+Example:
+
+```
+$ cat input.csv
+ID
+62fff91fc3be7f962ec7ea47
+62fff91fc3be7f962ec7ea4c
+62fff91fc3be7f962ec7ea4c
+62fff91fc3be7f962ec7ea4f
+62fff91fc3be7f962ec7ea51
+62fff9b6c3be7f962ec7ea56
+```
+
+```
+python3 scripts/pcs_incident_archiver.py input.csv
+Preparing to archive 5 incidents ...
+
+Ready to execute commands against your Prisma Cloud tenant ...
+Would you like to continue (y or yes)? y
+
+Archived incident 62fff9b6c3be7f962ec7ea56
+Archived incident 62fff91fc3be7f962ec7ea4c
+Archived incident 62fff91fc3be7f962ec7ea47
+Archived incident 62fff91fc3be7f962ec7ea51
+Archived incident 62fff91fc3be7f962ec7ea4f
+```
 
 #### pcs_images_packages_read
 

--- a/scripts/pcs_incident_archiver.py
+++ b/scripts/pcs_incident_archiver.py
@@ -1,0 +1,37 @@
+""" Bulk archive compute runtime incidents """
+
+# See workflow in scripts/README.md
+
+# pylint: disable=import-error
+from prismacloud.api import pc_api, pc_utility
+
+# --Configuration-- #
+
+parser = pc_utility.get_arg_parser()
+parser.add_argument(
+    "input_csv",
+    type=str,
+    help="Name of input CSV with incidents to archive in the 'ID' field.  This CSV MUST have a header row.",
+)
+args = parser.parse_args()
+
+# --Initialize-- #
+
+settings = pc_utility.get_settings(args)
+pc_api.configure(settings)
+
+# --Main-- #
+
+# Get incident IDs from CSV
+incidents_in = pc_utility.read_csv_file_text(args.input_csv)
+
+# Remove duplicate IDs
+incidents_to_archive = {s["ID"] for s in incidents_in}
+
+# Provide a chance to back out
+print(f"Preparing to archive {len(incidents_to_archive)} incidents ...")
+pc_utility.prompt_for_verification_to_continue(args)
+
+for incident in incidents_to_archive:
+    pc_api.audits_ack_incident(incident, ack_status=True)
+    print(f"Archived incident {incident}")


### PR DESCRIPTION
## Description

This PR:
- adds a method for acknowledging/archiving CWP runtime incidents
- adds a script to bulk archive runtime incidents based on the contents of a CSV file
- fixes some minor `_tags.py` syntax issues introduced in 53000c11f71e

## Motivation and Context

The UI does not currently provide a mechanism for bulk archiving runtime incidents.  As
customers tune their runtime rules, they would like to remove incidents that would not have
been generated under the tuned rule set.

## How Has This Been Tested?

The new method and script were tested against a 22.06.197 SaaS environment.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.