### PR TITLE
Update __init__.py

### DIFF
--- a/prismacloud/api/compute/__init__.py
+++ b/prismacloud/api/compute/__init__.py
@@ -14,6 +14,7 @@ from ._policies    import *
 from ._registry    import *
 from ._scans       import *
 from ._settings    import *
+from ._stats       import *
 from ._status      import *
 from ._tags        import *
 


### PR DESCRIPTION
## Description
Hello! I see the methods from "prismacloud-api-python/prismacloud/api/compute/_stats.py " are not being initiated, is there a techincal reason?

## Motivation and Context
I see there is some value in the quick reference of the already developed methods

## How Has This Been Tested?
Based on the commit, re-imported the library and the "stats" methods are now available for "pc_api"

## Types of changes
- New feature (non-breaking change which adds functionality)

## Checklist
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
