### PR TITLE
Handle API responses without a content-type header

### DIFF
--- a/prismacloud/api/compute/compute.py
+++ b/prismacloud/api/compute/compute.py
@@ -67,7 +67,7 @@ class PrismaCloudAPIComputeMixin():
                     if api_response.ok:
                         break # retry loop
             if api_response.ok:
-                if api_response.headers['Content-Type'] == 'text/csv':
+                if api_response.headers.get('Content-Type') == 'text/csv':
                     return api_response.content.decode('utf-8')
                 try:
                     result = json.loads(api_response.content)

--- a/prismacloud/api/posture/posture.py
+++ b/prismacloud/api/posture/posture.py
@@ -94,7 +94,7 @@ class PrismaCloudAPIMixin():
                     if api_response.ok:
                         break # retry loop
             if api_response.ok:
-                if api_response.headers['Content-Type'] == 'text/csv':
+                if api_response.headers.get('Content-Type') == 'text/csv':
                     return api_response.content.decode('utf-8')
                 try:
                     result = json.loads(api_response.content)

--- a/prismacloud/api/version.py
+++ b/prismacloud/api/version.py
@@ -1,3 +1,3 @@
 """ version file """
 
-version = '4.1.2'
+version = '4.1.3'


### PR DESCRIPTION
This commit avoids a `KeyError: 'content-type'` error when API responses do not include a `content-type:` header.

## Description

Use `.get()` method on `api_response.headers` to handle scenarios where the compute API response does not include the `content-type` header.

## Motivation and Context

Avoids this stack trace:
```
Traceback (most recent call last):
  File "/home/cfarquhar/projects/prismacloud-api-python/scripts/pcs_incident_archiver.py", line 36, in <module>
    pc_api.audits_ack_incident(incident, ack_status=True)
  File "/home/cfarquhar/projects/prismacloud-api-python/prismacloud/api/compute/_audits.py", line 18, in audits_ack_incident
    resp = self.execute_compute('PATCH', 'api/v1/audits/incidents/acknowledge/%s' % incident_id, body_params=body_params)
  File "/home/cfarquhar/projects/prismacloud-api-python/prismacloud/api/compute/compute.py", line 70, in execute_compute
    if api_response.headers['Content-Type'] == 'text/csv':
  File "/home/cfarquhar/.pyenv/versions/test20220928a/lib/python3.10/site-packages/requests/structures.py", line 52, in __getitem__
    return self._store[key.lower()][1]
KeyError: 'content-type'
```

## How Has This Been Tested?

It used to stack trace when API responses did not include a `content-type:` header.  Now it no longer stack traces.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
