### PR TITLE
Make API working in Windows

### DIFF
--- a/prismacloud/api/pc_lib_utility.py
+++ b/prismacloud/api/pc_lib_utility.py
@@ -17,6 +17,15 @@ try:
 except NameError:
     pass
 
+try:
+    from pathlib import Path
+    homefolder = str(Path.home())
+except:
+    if "USERPROFILE" in os.environ:
+        homefolder = os.environ["USERPROFILE"]
+    else:
+        homefolder = os.environ["HOME"]
+        
 # --Description-- #
 
 # Prisma Cloud Helper library.
@@ -26,7 +35,7 @@ except NameError:
 class PrismaCloudUtility():
     """ Prisma Cloud Utility Class """
 
-    CONFIG_DIRECTORY = os.path.join(os.environ['HOME'], '.prismacloud')
+    CONFIG_DIRECTORY = os.path.join(homefolder, '.prismacloud')
     DEFAULT_CONFIG_FILE = os.path.join(CONFIG_DIRECTORY, 'credentials.json')
 
     @classmethod


### PR DESCRIPTION
## Description

Simple change to make the API working in Windows.

## Motivation and Context

It uses Linux/Posix only variables and it doesn't work in windows.
[Issue fixed: #146 ](https://github.com/PaloAltoNetworks/prismacloud-api-python/issues/146)

## How Has This Been Tested?

Working on my computer.

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
