### PR TITLE
FIXED: Typo in CWP 'Credential' endpoint's methods

### DIFF
--- a/prismacloud/api/compute/_credentials.py
+++ b/prismacloud/api/compute/_credentials.py
@@ -19,10 +19,10 @@ class CredentialsPrismaCloudAPIComputeMixin:
 
     def credential_list_delete(self, cred):
         return self.execute_compute(
-            'DELETE', '/api/v1/credentials/%s' % urllib.parse.quote(cred)
+            'DELETE', 'api/v1/credentials/%s' % urllib.parse.quote(cred)
         )
 
     def credential_list_usages_read(self, cred):
         return self.execute_compute(
-            'GET', '/api/v1/credentials/%s/usages' % urllib.parse.quote(cred)
+            'GET', 'api/v1/credentials/%s/usages' % urllib.parse.quote(cred)
         )


### PR DESCRIPTION
## Description

There is an extra "/" character that isn't compatible with the "execute_compute" method.

## Motivation and Context

We need to do a one-time maintenance of our instance

## How Has This Been Tested?

It hasn't, it just should follow the endpoint URL requirement of the dependent methods

## Screenshots (if appropriate)

N/A

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
